### PR TITLE
Update APR calculations fix

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,7 @@ inflation_genesis:
   gravity_account_address: cudos16n3lc7cywa68mg50qhp847034w88pntq8823tx
 apr_genesis:
   initial_height: 1068800
-  norm_time_passed: 0.852119746111849790
+  norm_time_passed: 0.701091267050712000
   blocks_per_day: 12345
   mint_denom: acudos
   gravity_account_address: cudos16n3lc7cywa68mg50qhp847034w88pntq8823tx

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ inflation_genesis:
 apr_genesis:
   initial_height: 1068800
   norm_time_passed: 0.701091267050712000
+  real_blocks_per_day: 14048
   blocks_per_day: 12345
   mint_denom: acudos
   gravity_account_address: cudos16n3lc7cywa68mg50qhp847034w88pntq8823tx

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	APRGenesis struct {
 		InitialHeight         int64  `yaml:"initial_height"`
 		NormTimePassed        string `yaml:"norm_time_passed"`
+		RealBlocksPerDay      string `yaml:"real_blocks_per_day"`
 		BlocksPerDay          string `yaml:"blocks_per_day"`
 		MintDenom             string `yaml:"mint_denom"`
 		GravityAccountAddress string `yaml:"gravity_account_address"`

--- a/internal/tasks/apr.go
+++ b/internal/tasks/apr.go
@@ -9,7 +9,6 @@ import (
 	cudoMintTypes "github.com/CudoVentures/cudos-node/x/cudoMint/types"
 	"github.com/CudoVentures/cudos-stats-v2-service/internal/config"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/forbole/juno/v2/node/remote"
 )

--- a/internal/tasks/apr.go
+++ b/internal/tasks/apr.go
@@ -9,6 +9,7 @@ import (
 	cudoMintTypes "github.com/CudoVentures/cudos-node/x/cudoMint/types"
 	"github.com/CudoVentures/cudos-stats-v2-service/internal/config"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/forbole/juno/v2/node/remote"
 )
@@ -30,7 +31,12 @@ func getCalculateAPRHandler(genesisState cudoMintTypes.GenesisState, cfg config.
 			return fmt.Errorf("failed to get last block height %s", err)
 		}
 
-		mintAmountInt, err := calculateMintedTokensSinceHeight(genesisState, cfg.APRGenesis.InitialHeight, latestBlockHeight, 30.43)
+		realBlocksPerDay, ok := sdk.NewIntFromString(cfg.APRGenesis.RealBlocksPerDay)
+		if !ok {
+			return fmt.Errorf("failed to parse RealBlocksPerDay %s", cfg.APRGenesis.RealBlocksPerDay)
+		}
+
+		mintAmountInt, err := calculateMintedTokensSinceHeight(genesisState, cfg.APRGenesis.InitialHeight, latestBlockHeight, 30.43, realBlocksPerDay)
 		if err != nil {
 			return fmt.Errorf("failed to calculated minted tokens: %s", err)
 		}


### PR DESCRIPTION
This fixes the APR calculations a bit more by computing the next month's estimated block height from the real block rate rather than the presumed block rate, which is intentionally too low.